### PR TITLE
README.md: added missing rules from RFC 2234

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ rules of the ABNF definition.
                                ; 8 bits of data
 
         SP             =  %x20
+	                       ; space
+
+        VCHAR          =  %x21-7E
+                               ; visible (printing) characters
+
+        WSP            =  SP / HTAB
+                               ; white space
 
 ### Regex Support
 


### PR DESCRIPTION
The "Core rules" section of this document was missing the final items from Section 6.1 of RFC 2234, "Core Rules".  They exist at the top of page 12 of that document (from the "; space" for SP (the core rule having been included, only missing the comment) through the WSP definition), and were simply missing in the README.  I've not checked to ensure that the code handles them correctly, though I presume it does.